### PR TITLE
Bind errors on login page are shown before the actual save is done.

### DIFF
--- a/app-ui/src/main/java/my/domui/app/ui/pages/login/LoginPage.java
+++ b/app-ui/src/main/java/my/domui/app/ui/pages/login/LoginPage.java
@@ -23,7 +23,7 @@ import to.etc.util.StringTool;
  * Created on 30-7-17.
  */
 public class LoginPage extends UrlPage {
-	int					m_failcount;
+	private int	m_failcount;
 
 	static public final String	FORCE_TOP	=
 		"\nif(parent.location.href != self.location.href) {\n"		// Make sure we're not in a frame

--- a/app-ui/src/main/java/my/domui/app/ui/pages/management/UserEditPage.java
+++ b/app-ui/src/main/java/my/domui/app/ui/pages/management/UserEditPage.java
@@ -48,6 +48,9 @@ public class UserEditPage extends BasicPage {
 	}
 
 	private void save() throws Exception {
+		if (bindErrors()) {
+			return;
+		}
 		//-- Password change?
 		String p1 = getPassword1();
 		String p2 = getPassword2();


### PR DESCRIPTION
In case of bind errors on the login page the save is not done.